### PR TITLE
🚒 fixed the react state examples to use the constructor

### DIFF
--- a/src/slides/react-state/react-state.js
+++ b/src/slides/react-state/react-state.js
@@ -48,6 +48,13 @@ const Slide9 = ReplFrameSlide(
   "https://repl.it/@AbdellaPurvi/react-state-exercise-2?lite=true"
 );
 
+const Slide10 = BasicSlideMaker(
+  `Using State Correctly`,
+  `Do not modify state directly, instead use setState`,
+  `State updates may be asynchronous, do not rely on them for calculating the next state. Instead use a callback function with prevState`,
+  `State updates are shallow merged.`
+);
+
 export const reactStateSlideSet = [
   Slide1,
   Slide2,
@@ -57,5 +64,6 @@ export const reactStateSlideSet = [
   Slide6,
   Slide7,
   Slide8,
-  Slide9
+  Slide9,
+  Slide10
 ];

--- a/src/slides/react-state/state-example-1.js
+++ b/src/slides/react-state/state-example-1.js
@@ -1,20 +1,24 @@
-import React from 'react';
+import React from "react";
 
 export class StatefulComponent extends React.Component {
-
   // in classes, you can assign properties to the object like this, it sort of looks like
   // object notation, and it takes a little while to get used to.
   // Think of it like this - when you make an Instance of StatefulComponent, it will have .state on it as a property
   // inside of the definition of of the class, you can reference state by using the this keyword! ie, this.state
-  state = {
-    name: 'Kamala Khan',
-    age: 17
-  };
+  constructor(props) {
+    super(props);
+    this.state = {
+      name: "Kamala Khan",
+      age: 17
+    };
+  }
 
   render() {
-    return <div>
-      Hello {this.state.name},
-      Can't believe you're {this.state.age} years old!
-    </div>
+    return (
+      <div>
+        Hello {this.state.name}, Can't believe you're {this.state.age} years
+        old!
+      </div>
+    );
   }
 }

--- a/src/slides/react-state/state-example-2.js
+++ b/src/slides/react-state/state-example-2.js
@@ -1,20 +1,21 @@
-import React from 'react';
+import React from "react";
 
 export class StatefulComponent extends React.Component {
-  state = {
-    name: 'Carol Danvers',
-    age: 17
-  };
+  constructor(props) {
+    super(props);
+    this.state = {
+      name: "Carol Danvers",
+      age: 17
+    };
+  }
 
   // this is a lifecycle hook! There are a few in react, what they are, are methods that fire at certain points
   // in a react class components life - constructor for example fires at the very beginning of the lifecycle
   componentDidMount() {
     // here you can see that an object is passed into the setState method, with just one property
-    this.setState(
-      {
-        name: 'Kamala Khan'
-      }
-    );
+    this.setState({
+      name: "Kamala Khan"
+    });
 
     // this would show you that the only property that updated on state is the name property
     // age is left alone! Shallow merges are non-destructive, they only replace or add properties, they don't remove them

--- a/src/slides/react-state/state-example-3.js
+++ b/src/slides/react-state/state-example-3.js
@@ -1,20 +1,25 @@
-import React from 'react';
+import React from "react";
 
 export class StatefulComponent extends React.Component {
-  state = {
-    name: 'Carol Danvers',
-    age: 17
-  };
+  constructor(props) {
+    super(props);
+    this.state = {
+      name: "Carol Danvers",
+      age: 17
+    };
+  }
 
-  componentDidMount(){
+  componentDidMount() {
     // updating the value of name this way would technically work - the value would change, but we wouldn't see it
-    this.state.name = 'Kamala Khan';
+    this.state.name = "Kamala Khan";
   }
 
   render() {
-    return <div>
-      Hello {this.state.name},
-      Can't believe you're {this.state.age} years old!
-    </div>
+    return (
+      <div>
+        Hello {this.state.name}, Can't believe you're {this.state.age} years
+        old!
+      </div>
+    );
   }
 }

--- a/src/slides/react-state/state-example-4.js
+++ b/src/slides/react-state/state-example-4.js
@@ -1,21 +1,26 @@
-import React from 'react';
+import React from "react";
 
 export class StatefulComponent extends React.Component {
-  state = {
-    name: 'Carol Danvers',
-    age: 17
-  };
+  constructor(props) {
+    super(props);
+    this.state = {
+      name: "Carol Danvers",
+      age: 17
+    };
+  }
 
-  componentDidMount(){
+  componentDidMount() {
     // updating the value of name this way triggers a re-render, meaning the hello {this.state.name} will correctly
     //display Kamala Khan!
-    this.setState({name: 'Kamala Khan'})
+    this.setState({ name: "Kamala Khan" });
   }
 
   render() {
-    return <div>
-      Hello {this.state.name},
-      Can't believe you're {this.state.age} years old!
-    </div>
+    return (
+      <div>
+        Hello {this.state.name}, Can't believe you're {this.state.age} years
+        old!
+      </div>
+    );
   }
 }


### PR DESCRIPTION
Our react state examples were excluding the part where the state had to be initialized using the constructor methods on classes. So I updated that in this PR.

See here the part about always initializing the component state in the constructor method of the class:
https://reactjs.org/docs/state-and-lifecycle.html#adding-local-state-to-a-class