### PR TITLE
Move lifecycle slides after state

### DIFF
--- a/src/slideDecks.js
+++ b/src/slideDecks.js
@@ -57,8 +57,8 @@ const reactSlideList = [
   ...functionComponentSlideSet,
   ...reactPropsSlideSet,
   ...classComponentSlideSet,
-  ...lifecycleSlideSet,
   ...reactStateSlideSet,
+  ...lifecycleSlideSet,
   ...reactHooksSlideSet,
 ];
 


### PR DESCRIPTION
Some of the info in the lifecycle slides won't make much sense without prior knowledge of state (e.g., `getDerivedStateFromProps`), so I think it makes sense to introduce state first, then lifecycle methods.